### PR TITLE
Support non-Mac setups

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -15,3 +15,9 @@ WORLD_NAME=static_red_square_target
 
 # The region of the S3 bucket in which you want to store the model.
 ROS_AWS_REGION=us-east-1
+
+# Number of CPU's to give the VM, max = number of physical cores.
+NUM_CPUS=2
+
+# RAM in MB
+RAM_MB=4096

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Keywords: Reinforcement learning, AWS, RoboMaker, Drone
 - An AWS S3 bucket - To store the trained reinforcement learning model
 
 ## Get Started
-1. Install Vagrant and Virtualbox
+1. Install [Vagrant](https://www.vagrantup.com/docs/installation/) and [Virtualbox](https://www.virtualbox.org/wiki/Downloads)
 
 Run these commands from your host machine
 
@@ -27,6 +27,13 @@ To build the simulation, run these commands
 
 5. `deeprotor ssh` (use `deeprotor up` if the VM is not already on)
 6. (In the ssh session) `deeprotor build-local`
+
+The virtual camera sensor requires a running X server, and the easiset way to get that is to run the training and evaluation commands in a GUI terminal. Deepracer installs a GUI. To finish setup
+
+7. `deepracer halt` from the host to stop the VM
+8. Open the VM's settings through the VirutalBox GUI, go to display, increase the video RAM and enable 3d acceleration.
+9. Select `VMSVGA` as the graphics driver. Gazebo appears to be unstable with `VboxVGA`.
+10. `deepracer up` to start the VM. You should now be able to access the VM GUI from the VirtualBox GUI 
 
 ### AWS Account Setup
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ Vagrant.configure("2") do |config|
   config.disksize.size='50GB'
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = 8192
-    vb.cpus = 4
+    vb.memory = ENV["RAM_MB"] ? ENV["RAM_MB"] : 4096
+    vb.cpus = ENV["NUM_CPUS"] ? ENV["NUM_CPUS"] : 2
   end
 
   config.vm.provision "deps", type: "shell", inline: <<-SHELL

--- a/scripts/deeprotor
+++ b/scripts/deeprotor
@@ -5,7 +5,7 @@
 # From your host machine, run `deeprotor setup` to add the deeprotor command to your
 # profile, create the VM, and install project dependencies.
 
-source $(realpath $(dirname $BASH_SOURCE))/deeprotor-paths.sh
+source $(dirname $BASH_SOURCE)/deeprotor-paths.sh
 
 deeprotor() {
   case "$1" in

--- a/scripts/deeprotor-common.sh
+++ b/scripts/deeprotor-common.sh
@@ -8,3 +8,13 @@ quit() {
   echo $@
   exit 1
 }
+
+export_env_and_creds() {
+  ENVFILE=${ENVFILE:-.env}
+  CREDFILE=${CREDFILE:-.creds}
+  
+  set -o allexport
+    [ -e "$ENVFILE" ] && source $ENVFILE
+    [ -e "$CREDFILE" ] && source $CREDFILE
+  set +o allexport
+}

--- a/scripts/deeprotor-guest.sh
+++ b/scripts/deeprotor-guest.sh
@@ -8,7 +8,7 @@ ROS_BASE_SETUP=/opt/ros/kinetic/setup.bash
 # Configures roslaunch to use the built project, including the base setup.
 ROS_RUN_SETUP=$DEEPROTOR_ROOT/simulation_ws/install/setup.bash
 
-deeprotor() {
+deeprotor-guest() {
   case "$1" in
     setup)
       setup
@@ -36,14 +36,7 @@ deeprotor() {
 }
 
 launch-simulation() {
-  ENVFILE=${ENVFILE:-.env}
-  CREDFILE=${CREDFILE:-.creds}
-  
-  set -o allexport
-    [ -e "$ENVFILE" ] && source $ENVFILE
-    [ -e "$CREDFILE" ] && source $CREDFILE
-  set +o allexport
-  
+  export_env_and_creds
   source $ROS_RUN_SETUP
 
   if [ "$2" == "--verbose" ]; then
@@ -75,13 +68,13 @@ refresh_creds() {
 
 setup() {
   echo "Installing ROS"
-  bash scripts/setup_ros.sh || quit "Error installing ROS"
+  bash -x scripts/setup_ros.sh || quit "Error installing ROS"
 
   echo "Adding ROS setup to profile"
   source_from_profile $ROS_BASE_SETUP
 
   echo "Installing project dependencies"
-  bash scripts/setup_dependencies.sh || quit "Error installing dependencies"
+  bash -x scripts/setup_dependencies.sh || quit "Error installing dependencies"
 
   echo "Adding deeprotor CLI to profile"
   source_from_profile $DEEPROTOR_CLI
@@ -96,4 +89,4 @@ source_from_profile() {
   fi
 }
 
-deeprotor $@
+deeprotor-guest $@


### PR DESCRIPTION
- Add env flags to specify VM RAM and nCPU
- Use sudo when installing vagrant plugins
- Allow specifying the host profile to update as `deeprotor setup ~/.bashrc`
- Add VM display configuration info to the README
- Add tracing and update names for readability

