### PR TITLE
Use a headless X server

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -21,3 +21,19 @@ NUM_CPUS=2
 
 # RAM in MB
 RAM_MB=4096
+
+# Width of the virtual display in pixels.
+SCREEN_WIDTH=1280
+
+# Height of the virtual display in pixels
+SCREEN_HEIGHT=720
+
+# Location to store the Xauthority file used by the virtual desktop, which 
+# contains credentials that VNC and Gazebo need to connect to the X server.
+# You shouldn't need to change this unless trying to run multiple instances
+# on a single machine.
+XAUTHORITY_PATH=~/.Xauthority
+
+# Number to assign the virtual display. You shouldn't need to change this
+# unless trying to run multiple instances on a single machine.
+XDISPLAY_NUM=0

--- a/.env.default
+++ b/.env.default
@@ -15,3 +15,9 @@ WORLD_NAME=static_red_square_target
 
 # The region of the S3 bucket in which you want to store the model.
 ROS_AWS_REGION=us-east-1
+
+# Number of CPU's to give the VM, max = number of physical cores.
+NUM_CPUS=2
+
+# RAM in MB
+RAM_MB=4096

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Keywords: Reinforcement learning, AWS, RoboMaker, Drone
 - An AWS S3 bucket - To store the trained reinforcement learning model
 
 ## Get Started
-1. Install Vagrant and Virtualbox
+1. Install [Vagrant](https://www.vagrantup.com/docs/installation/) and [Virtualbox](https://www.virtualbox.org/wiki/Downloads)
 
 Run these commands from your host machine
 
@@ -27,6 +27,13 @@ To build the simulation, run these commands
 
 5. `deeprotor ssh` (use `deeprotor up` if the VM is not already on)
 6. (In the ssh session) `deeprotor build-local`
+
+The virtual camera sensor requires a running X server, and the easiset way to get that is to run the training and evaluation commands in a GUI terminal. Deepracer installs a GUI. To finish setup
+
+7. `deepracer halt` from the host to stop the VM
+8. Open the VM's settings through the VirutalBox GUI, go to display, increase the video RAM and enable 3d acceleration.
+9. Select `VMSVGA` as the graphics driver. Gazebo appears to be unstable with `VboxVGA`.
+10. `deepracer up` to start the VM. You should now be able to access the VM GUI from the VirtualBox GUI 
 
 ### AWS Account Setup
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,7 @@ To build the simulation, run these commands
 5. `deeprotor ssh` (use `deeprotor up` if the VM is not already on)
 6. (In the ssh session) `deeprotor build-local`
 
-The virtual camera sensor requires a running X server, and the easiset way to get that is to run the training and evaluation commands in a GUI terminal. Deepracer installs a GUI. To finish setup
-
-7. `deepracer halt` from the host to stop the VM
-8. Open the VM's settings through the VirutalBox GUI, go to display, increase the video RAM and enable 3d acceleration.
-9. Select `VMSVGA` as the graphics driver. Gazebo appears to be unstable with `VboxVGA`.
-10. `deepracer up` to start the VM. You should now be able to access the VM GUI from the VirtualBox GUI 
+Deeprotor also installs a desktop environment. This is required for training, evaluation, and inspecting the simulation through the Gazebo UI. The desktop is started automatically when needed but can also be run manually with `deeprotor run-gui`. Once started, you can access the GUI over VNC at `localhost:5900` on the host. [VNC Connect](https://www.realvnc.com/en/connect/download/viewer/) is the recommended VNC client.
 
 ### AWS Account Setup
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,10 +22,14 @@ Vagrant.configure("2") do |config|
     ]
   end
 
+  # Forward VNC port
+  config.vm.network "forwarded_port", guest: 5900, host: 5900
+
   config.vm.provision "deps", type: "shell", inline: <<-SHELL
     apt-get update
-    apt-get install -y lxqt xinit ntp
-    echo "Reboot to start using UI"
+    apt-get install -y lxqt xinit ntp xvfb x11vnc
+    # Boot to command line, not GUI
+    systemctl set-default multi-user.target
   SHELL
 
   config.vm.provision "env", type: "shell", privileged: false, inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ Vagrant.configure("2") do |config|
   config.disksize.size='50GB'
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = 8192
-    vb.cpus = 4
+    vb.memory = ENV["RAM_MB"] ? ENV["RAM_MB"] : 4096
+    vb.cpus = ENV["NUM_CPUS"] ? ENV["NUM_CPUS"] : 2
   end
 
   config.vm.provision "deps", type: "shell", inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,13 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     vb.memory = ENV["RAM_MB"] ? ENV["RAM_MB"] : 4096
     vb.cpus = ENV["NUM_CPUS"] ? ENV["NUM_CPUS"] : 2
+
+    vb.customize [
+      "modifyvm", :id,
+      "--accelerate3d", "on",
+      "--graphicscontroller", "vmsvga",
+      "--vram", "128"
+    ]
   end
 
   config.vm.provision "deps", type: "shell", inline: <<-SHELL

--- a/scripts/deeprotor
+++ b/scripts/deeprotor
@@ -5,7 +5,7 @@
 # From your host machine, run `deeprotor setup` to add the deeprotor command to your
 # profile, create the VM, and install project dependencies.
 
-source $(realpath $(dirname $BASH_SOURCE))/deeprotor-paths.sh
+source $(dirname $BASH_SOURCE)/deeprotor-paths.sh
 
 deeprotor() {
   case "$1" in

--- a/scripts/deeprotor-common.sh
+++ b/scripts/deeprotor-common.sh
@@ -8,3 +8,13 @@ quit() {
   echo $@
   exit 1
 }
+
+export_env_and_creds() {
+  ENVFILE=${ENVFILE:-.env}
+  CREDFILE=${CREDFILE:-.creds}
+  
+  set -o allexport
+    [ -e "$ENVFILE" ] && source $ENVFILE
+    [ -e "$CREDFILE" ] && source $CREDFILE
+  set +o allexport
+}

--- a/scripts/deeprotor-guest.sh
+++ b/scripts/deeprotor-guest.sh
@@ -8,7 +8,7 @@ ROS_BASE_SETUP=/opt/ros/kinetic/setup.bash
 # Configures roslaunch to use the built project, including the base setup.
 ROS_RUN_SETUP=$DEEPROTOR_ROOT/simulation_ws/install/setup.bash
 
-deeprotor() {
+deeprotor-guest() {
   case "$1" in
     setup)
       setup
@@ -36,14 +36,7 @@ deeprotor() {
 }
 
 launch-simulation() {
-  ENVFILE=${ENVFILE:-.env}
-  CREDFILE=${CREDFILE:-.creds}
-  
-  set -o allexport
-    [ -e "$ENVFILE" ] && source $ENVFILE
-    [ -e "$CREDFILE" ] && source $CREDFILE
-  set +o allexport
-  
+  export_env_and_creds
   source $ROS_RUN_SETUP
 
   if [ "$2" == "--verbose" ]; then
@@ -75,13 +68,13 @@ refresh_creds() {
 
 setup() {
   echo "Installing ROS"
-  bash scripts/setup_ros.sh || quit "Error installing ROS"
+  bash -x scripts/setup_ros.sh || quit "Error installing ROS"
 
   echo "Adding ROS setup to profile"
   source_from_profile $ROS_BASE_SETUP
 
   echo "Installing project dependencies"
-  bash scripts/setup_dependencies.sh || quit "Error installing dependencies"
+  bash -x scripts/setup_dependencies.sh || quit "Error installing dependencies"
 
   echo "Adding deeprotor CLI to profile"
   source_from_profile $DEEPROTOR_CLI
@@ -96,4 +89,4 @@ source_from_profile() {
   fi
 }
 
-deeprotor $@
+deeprotor-guest $@

--- a/scripts/deeprotor-guest.sh
+++ b/scripts/deeprotor-guest.sh
@@ -8,9 +8,6 @@ ROS_BASE_SETUP=/opt/ros/kinetic/setup.bash
 # Configures roslaunch to use the built project, including the base setup.
 ROS_RUN_SETUP=$DEEPROTOR_ROOT/simulation_ws/install/setup.bash
 
-export DISPLAY=:$XDISPLAY
-export XAUTHORITY=~/.Xauthority
-
 deeprotor-guest() {
   case "$1" in
     setup)

--- a/scripts/deeprotor-guest.sh
+++ b/scripts/deeprotor-guest.sh
@@ -8,6 +8,9 @@ ROS_BASE_SETUP=/opt/ros/kinetic/setup.bash
 # Configures roslaunch to use the built project, including the base setup.
 ROS_RUN_SETUP=$DEEPROTOR_ROOT/simulation_ws/install/setup.bash
 
+export DISPLAY=:$XDISPLAY
+export XAUTHORITY=~/.Xauthority
+
 deeprotor-guest() {
   case "$1" in
     setup)
@@ -21,6 +24,9 @@ deeprotor-guest() {
       shift
       launch-simulation evaluate $@ 
       ;;
+    run-gui)
+      run_gui
+      ;;
     build-local)
       shift
       build_local $@
@@ -30,20 +36,60 @@ deeprotor-guest() {
       refresh_creds $@ 
       ;;
     *)
-      echo "Usage: deeprotor train-local|build-local|refresh-creds|cd|setup"
+      echo "Usage: deeprotor cd|setup|refresh-creds|build-local|train-local||run-gui"
       ;;
   esac
 }
 
-launch-simulation() {
+# Sources and exports variables necessary to run the GUI or simulation.
+export_run_env() {
   export_env_and_creds
   source $ROS_RUN_SETUP
+  export DISPLAY=":$XDISPLAY_NUM"
+  export XAUTHORITY="$XAUTHORITY_PATH"
+}
 
+launch-simulation() {  
+  export_run_env
+  start_gui
   if [ "$2" == "--verbose" ]; then
     roslaunch -v deeprotor_simulation $1.launch verbose:=true
   else
     roslaunch deeprotor_simulation $1.launch
   fi
+}
+
+# Start a headless X server running an LXQT desktop
+run_Xvfb() {
+  xvfb-run \
+    --server-num=$XDISPLAY_NUM \
+    --auth-file=$XAUTHORITY \
+    --server-args="-screen 0 ${SCREEN_WIDTH}x${SCREEN_HEIGHT}x24" \
+    startlxqt
+}
+
+# Start a VNC server accessible without a password at localhost:5900
+run_x11vnc() {
+  x11vnc \
+    -auth $XAUTHORITY \
+    -display $DISPLAY \
+    -nevershared \
+    -loop \
+    -forever
+}
+
+# Start the GUI in the background and kill it when the shell exits 
+start_gui() {
+  trap 'kill $(jobs -p)' EXIT
+  run_Xvfb &
+  run_x11vnc &
+}
+
+# Standalone command to start the gui
+run_gui() {
+  export_run_env
+  start_gui
+  tail -f /dev/null
 }
 
 build_local() {


### PR DESCRIPTION
- Use xvfb to run a virtual display.
- Use x11vnc to provide GUI access at localhost:5900 on the host

Everything should now be doable through the command line.

```
host > deeprotor ssh
guest-ssh > deeprotor train-local --verbose
```

This will automatically start an X server and tear it down when train-local is killed. While it's running, you can access the GUI over VNC at localhost:5900.

depends on https://github.com/Kolefn/cantina-deeprotor/pull/3