### PR TITLE
add realpath function for macos compatability

### DIFF
--- a/scripts/deeprotor-paths.sh
+++ b/scripts/deeprotor-paths.sh
@@ -1,4 +1,20 @@
+#!/usr/bin/env bash
 # Exports project paths on the host and guest.
+
+# Credit: https://stackoverflow.com/users/2351351/geoff-nixon
+# source: https://stackoverflow.com/a/18443300
+realpath() {
+  OURPWD=$PWD
+  cd "$(dirname "$1")"
+  LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  REALPATH="$PWD/$(basename "$1")"
+  cd "$OURPWD"
+  echo "$REALPATH"
+}
 
 export DEEPROTOR_ROOT=$(realpath $(dirname $BASH_SOURCE)/..)
 export DEEPROTOR_CLI=$DEEPROTOR_ROOT/scripts/deeprotor


### PR DESCRIPTION
I was getting a "realpath command not found" error when running `deeprotor-paths.sh`. This should allow MacOS hosts to run the script. 
