### PR TITLE
Feature/restore local training from checkpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ simulation_ws/build
 simulation_ws/bundle
 simulation_ws/install
 simulation_ws/log
+
+*.pyc

--- a/scripts/deeprotor-guest.sh
+++ b/scripts/deeprotor-guest.sh
@@ -46,14 +46,24 @@ export_run_env() {
   export XAUTHORITY="$XAUTHORITY_PATH"
 }
 
-launch-simulation() {  
+launch-simulation(){
   export_run_env
   start_gui
-  if [ "$2" == "--verbose" ]; then
-    roslaunch -v $SIMULATION_PACKAGE $1.launch verbose:=true
-  else
-    roslaunch $SIMULATION_PACKAGE $1.launch
-  fi
+  
+  gazebo_verbose='false'
+  gazebo_gui='false'
+  restore='false'
+  OPTIND=2
+  while getopts 'vgr' flag; do
+    case "${flag}" in
+      v) gazebo_verbose='true' ;;
+      g) gazebo_gui='true' ;;
+      r) restore='true' ;;
+      *) echo "-v (enable verbose gazebo logs) -g (enable gazebo gui) -r (restore the model using the last checkpoint)" ;;
+    esac
+  done
+
+  roslaunch -v $SIMULATION_PACKAGE $1.launch verbose:=$gazebo_verbose gui:=$gazebo_gui restore_from_checkpoint:=$restore
 }
 
 # Start a headless X server running an LXQT desktop

--- a/simulation_ws/src/deeprotor_simulation/launch/local_training.launch
+++ b/simulation_ws/src/deeprotor_simulation/launch/local_training.launch
@@ -2,6 +2,7 @@
 <launch>
     <arg name="gui" default="false" />
     <arg name="verbose" default="false"/>
+    <arg name="restore_from_checkpoint" default="false"/>
 
     <param name="WORLD_NAME" value="$(env WORLD_NAME)" />
     <param name="MODEL_S3_BUCKET" value="$(env MODEL_S3_BUCKET)" />
@@ -15,5 +16,5 @@
          <arg name="verbose" default="$(arg verbose)"/>
     </include>
 
-    <node name="agent" pkg="deeprotor_simulation" type="run_local_rl_agent.sh" output="screen" required="true"/>
+    <node name="agent" pkg="deeprotor_simulation" type="run_local_rl_agent.sh" output="screen" required="true" args="$(arg restore_from_checkpoint)"/>
 </launch>

--- a/simulation_ws/src/deeprotor_simulation/scripts/run_local_rl_agent.sh
+++ b/simulation_ws/src/deeprotor_simulation/scripts/run_local_rl_agent.sh
@@ -4,4 +4,4 @@ set -ex
 
 export NODE_TYPE=SIMULATION_WORKER
 
-python3 -m markov.single_machine_training_worker
+python3 -m markov.single_machine_training_worker --restore-from-checkpoint $1


### PR DESCRIPTION
#5 

**main features**
- Add `-r` flag to `deeprotor train-local` which will cause the launch script to bootstrap the model using the most recent checkpoint. This allows you to pick up training where you left off. 
- Add `-g` flag to run the Gazebo gui when training. 
- replace `--verbose` with `-v`

**misc**
- Git ignore python cache files
