### PR TITLE
feature/periodically-delete-local-checkpoints

### DIFF
--- a/simulation_ws/src/sagemaker_rl_agent/markov/s3_boto_data_store.py
+++ b/simulation_ws/src/sagemaker_rl_agent/markov/s3_boto_data_store.py
@@ -98,7 +98,7 @@ class S3BotoDataStore(DataStore):
                         s3_client.delete_object(Bucket=self.params.bucket,
                                                 Key=obj["Key"])
                         num_files += 1
-
+                    utils.delete_local_checkpoint(self.params.checkpoint_dir, checkpoint_number_to_delete)
                     print("Deleted %s model files from S3" % num_files)
                     return True
         except Exception as e:

--- a/simulation_ws/src/sagemaker_rl_agent/markov/utils.py
+++ b/simulation_ws/src/sagemaker_rl_agent/markov/utils.py
@@ -1,4 +1,4 @@
-import os
+import os, glob
 import logging
 import time
 
@@ -35,6 +35,11 @@ def wait_for_checkpoint(checkpoint_dir, data_store=None, retries=10):
         retries=retries,
         checkpoint_dir=checkpoint_dir,
     ))
+
+def delete_local_checkpoint(checkpoint_dir, checkpoint_num):
+    for filename in glob.glob(checkpoint_dir + "/" + str(checkpoint_num) + "_*"):
+        print("deleting checkpoint file" + filename)
+        os.remove(filename) 
 
 def write_frozen_graph(graph_manager, local_path):
     if not os.path.exists(local_path):


### PR DESCRIPTION
May address the bug described in #8 

- Adds a util function for deleting local checkpoints
- Places the delete such that only the most recent 4 checkpoints are kept (this logic already existed for checkpoints hosted on AWS S3 - so I simply placed the local delete there).
